### PR TITLE
Allow to configure a default mail-domain for the username

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ As simple as running:
       bitbucket:
         allow: TeamOne(admin), TeamX(admin|collaborator), TeamZ
         ttl: 604800 # make cache live for 7 days, optional, default = 1 day
+        defaultMailDomain: gmail.com # specify a default domain for the username
     ...
     packages:
       '@myscope/*':
@@ -42,7 +43,7 @@ appropriate role in the team.
 After this it is becomes possible to configure team-based access to the packages
 as seen on config example above.
 
-### Loging In
+### Logging In
 
 To log in using NPM, run:
 
@@ -52,6 +53,13 @@ To log in using NPM, run:
 Since the username for bitbucket is the email addresses 
 and cannot contain `@`, replace the `@` with two peiods `..`
 The email address is then parsed and converted to a normal email address for authentication
+
+Alternatively you can specify the `defaultMailDomain` configuration option,
+if most (or all) your users use the same mail provider or an own mail server.
+In this case the users have to provide only the local-part of there bitbucket
+email address (the part before the `@`) as a username.
+It is still possible to override the default domain via the `..` convention
+mentioned above.
 
 ### Notes
 


### PR DESCRIPTION
Add a new "defaultMailDomain" option to the configuration. 

This is very handy, when all users of the NPM-Registry have the same mail domain (e. g. in companies). 
This way you can avoid the ugly "@" --> ".." replacement convention for user verdaccio user names.