### PR TITLE
Fixes #12 when verdaccio searches for the 'adduser' function

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "npm run build && mocha"
   },
   "main": "lib/index.js",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Verdaccio module to authenticate users via Bitbucket",
   "keywords": [
     "sinopia",

--- a/src/index.js
+++ b/src/index.js
@@ -121,4 +121,8 @@ Auth.prototype.authenticate = function authenticate(username, password, done) {
   });
 };
 
+Auth.prototype.adduser = function add_user(user, password, cb) {
+  cb(null, true);
+}
+
 module.exports = Auth;

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ Auth.prototype.authenticate = function authenticate(username, password, done) {
   });
 };
 
-Auth.prototype.adduser = function add_user(user, password, cb) {
+Auth.prototype.adduser = function addUser(user, password, cb) {
   cb(null, true);
 }
 


### PR DESCRIPTION
Verdaccio's `add_user` function is used when using the `npm adduser` command.  Since users should already exist in Bitbucket, this function will do a simple passthrough, but will not fail.  Therefore logging in using the `adduser` function will not fail.  This means that documentation from the verdaccio repository remains 100% valid.